### PR TITLE
fix(i18n): translate job types and present label in French

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Portfolio v1.2.0
+# Portfolio v1.2.1
 
 Personal developer portfolio built with [**Next.js 16**](https://nextjs.org/) (App Router) and [**Sanity.io**](https://www.sanity.io/) as headless CMS. Single-page site with sections: Home, About, Projects, Work History, Contact. All content is managed in Sanity and fetched server-side via GROQ queries.
 

--- a/components/JobCard/JobCard.tsx
+++ b/components/JobCard/JobCard.tsx
@@ -11,6 +11,7 @@ interface JobCardProps {
   showDescription?: boolean;
   locale: string;
   presentLabel: string;
+  jobTypeLabel: string;
 }
 
 export default function JobCard({
@@ -18,6 +19,7 @@ export default function JobCard({
   showDescription = true,
   locale,
   presentLabel,
+  jobTypeLabel,
 }: JobCardProps) {
   const role = localize(job, 'role', locale) as string;
   const location = localize(job, 'location', locale) as string;
@@ -36,7 +38,7 @@ export default function JobCard({
       <div className="text-sm font-light">
         {job.date.start} - {job.date?.present ? presentLabel : job.date.end}
         <span className="ml-1">
-          (<span className="inline-block first-letter:uppercase">{job.jobType}</span>)
+          (<span className="inline-block first-letter:uppercase">{jobTypeLabel}</span>)
         </span>
       </div>
       <div className="text-sm font-extralight">{location}</div>

--- a/components/WorkHistorySection.tsx
+++ b/components/WorkHistorySection.tsx
@@ -63,6 +63,7 @@ export default function WorkHistorySection({ jobs, locale }: WorkHistoryProps) {
                 job={item}
                 locale={locale}
                 presentLabel={t('present')}
+                jobTypeLabel={t(item.jobType)}
               />
             </motion.div>
           ))}
@@ -86,7 +87,12 @@ export default function WorkHistorySection({ jobs, locale }: WorkHistoryProps) {
                       icon={RxCross2}
                       className="fixed right-2 top-10 rounded-full border-[1px] bg-white px-3 py-2 text-tertiary shadow transition-colors duration-300"
                     ></Button>
-                    <JobCard job={item} locale={locale} presentLabel={t('present')} />
+                    <JobCard
+                      job={item}
+                      locale={locale}
+                      presentLabel={t('present')}
+                      jobTypeLabel={t(item.jobType)}
+                    />
                   </motion.div>
                 ),
             )}

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,7 +22,10 @@
   },
   "workHistory": {
     "title": "Work history",
-    "present": "Present"
+    "present": "Present",
+    "full-time": "Full-time",
+    "internship": "Internship",
+    "part-time": "Part-time"
   },
   "contact": {
     "title": "Contact",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -22,7 +22,10 @@
   },
   "workHistory": {
     "title": "Parcours professionnel",
-    "present": "Présent"
+    "present": "Aujourd'hui",
+    "full-time": "Plein temps",
+    "internship": "Stage",
+    "part-time": "Temps partiel"
   },
   "contact": {
     "title": "Contact",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Add French translations for job types: full-time → Plein temps, internship → Stage, part-time → Temps partiel
- Change "Présent" → "Aujourd'hui" for current job label in FR
- Pass `jobTypeLabel` as prop to JobCard (dumb component pattern)

## Test plan
- [x] All 12 verify-site checks pass
- [x] Visual verification: "Aujourd'hui", "Plein temps", "Stage" display correctly in FR
- [x] No smart/dumb component pattern violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)